### PR TITLE
gpio: Create gpio.Group interface

### DIFF
--- a/gpio/group.go
+++ b/gpio/group.go
@@ -1,0 +1,59 @@
+package gpio
+
+import (
+	"errors"
+	"time"
+
+	"periph.io/x/conn/v3"
+	"periph.io/x/conn/v3/pin"
+)
+
+type GPIOValue uint64
+
+// Implementations that don't implement specific interface methods should
+// return GroupFeatureNotImplemented as the error to allow clients to
+// generically check for the condition.
+var GroupFeatureNotImplemented = errors.New("gpio group feature not implemented")
+
+// Group is an interface that an IO device can implement to manipulate multiple
+// IO Pins at one time. Performing GPIO Operations in this manner can dramatically 
+// simplify code and reduce IO Operation latency.
+//
+// Device specific code can also provide methods that return a Group that operates 
+// on a subset of the pins the device supports.
+type Group interface {
+	// The set of GPIO pins that make up this group. Implementations will
+	// typically Use gpio.PinIO, gpio.PinIn, or gpio.PinOut as the actual return
+	// value type.
+	Pins() []*pin.Pin
+	// Given a specific pin offset within the group, return that pin.
+	// For example, a pin group may be GPIO pins 3,5,7,9 in that order.
+	// ByOffset(1) returns GPIO pin 5.
+	ByOffset(number int) pin.Pin
+	// Given the unique name of a GPIO pin, return that pin.
+	ByName(name string) pin.Pin
+	// Given the specific GPIO pin number, return the corresponding
+	// pin from the group.
+	ByNumber(number int) pin.Pin
+	// Out writes the specified bitwise value to the pins. Bit 0 corresponds to
+	// the first pin in the set, bit 1 the second, etc. Only pins within the
+	// group that have mask bit set are modified. For example, if you have 8
+	// pins within the group and you want to write the value 0x0a to the lower
+	// 4 pins, you would use a mask of 0x0f.
+	//
+	// If the device doesn't support write operations, implementations should
+	// return gpio.GroupFeatureNotImplemented.
+	Out(value, mask GPIOValue) error
+	// Read reads the pins within the group, and returns the  value, ANDed with
+	// mask. If the device doesn't support read operations, implementations
+	// should return gpio.GroupFeatureNotImplemented.
+	Read(mask GPIOValue) (GPIOValue, error)
+	// WaitForEdge blocks for a GPIO line change event to happen. If the does
+	// not implement gpio.PinIn, or doesn't support this capability, 
+	// implementations should return gpio.GroupFeatureNotImplemented.
+	//
+	// Number is the GPIO pin number within the group that had an edge change.
+	WaitForEdge(timeout time.Duration) (number int, edge Edge, err error)
+	// conn.Resource brings in resource.Halt(), and fmt.Stringer
+	conn.Resource
+}

--- a/gpio/group.go
+++ b/gpio/group.go
@@ -15,7 +15,7 @@ import (
 type GPIOValue uint64
 
 // Implementations that don't implement specific interface methods should
-// return GroupFeatureNotImplemented as the error to allow clients to
+// return ErrGroupFeatureNotImplemented as the error to allow clients to
 // generically check for the condition.
 var ErrGroupFeatureNotImplemented = errors.New("gpio group feature not implemented")
 
@@ -46,15 +46,15 @@ type Group interface {
 	// 4 pins, you would use a mask of 0x0f.
 	//
 	// If the device doesn't support write operations, implementations should
-	// return gpio.GroupFeatureNotImplemented.
+	// return gpio.ErrGroupFeatureNotImplemented.
 	Out(value, mask GPIOValue) error
 	// Read reads the pins within the group, and returns the  value, ANDed with
 	// mask. If the device doesn't support read operations, implementations
-	// should return gpio.GroupFeatureNotImplemented.
+	// should return gpio.ErrGroupFeatureNotImplemented.
 	Read(mask GPIOValue) (GPIOValue, error)
 	// WaitForEdge blocks for a GPIO line change event to happen. If the does
 	// not implement gpio.PinIn, or doesn't support this capability,
-	// implementations should return gpio.GroupFeatureNotImplemented.
+	// implementations should return gpio.ErrGroupFeatureNotImplemented.
 	//
 	// Number is the GPIO pin number within the group that had an edge change.
 	WaitForEdge(timeout time.Duration) (number int, edge Edge, err error)

--- a/gpio/group.go
+++ b/gpio/group.go
@@ -1,3 +1,7 @@
+// Copyright 2025 The Periph Authors. All rights reserved.
+// Use of this source code is governed under the Apache License, Version 2.0
+// that can be found in the LICENSE file.
+
 package gpio
 
 import (
@@ -16,10 +20,10 @@ type GPIOValue uint64
 var GroupFeatureNotImplemented = errors.New("gpio group feature not implemented")
 
 // Group is an interface that an IO device can implement to manipulate multiple
-// IO Pins at one time. Performing GPIO Operations in this manner can dramatically 
+// IO Pins at one time. Performing GPIO Operations in this manner can dramatically
 // simplify code and reduce IO Operation latency.
 //
-// Device specific code can also provide methods that return a Group that operates 
+// Device specific code can also provide methods that return a Group that operates
 // on a subset of the pins the device supports.
 type Group interface {
 	// The set of GPIO pins that make up this group. Implementations will
@@ -49,7 +53,7 @@ type Group interface {
 	// should return gpio.GroupFeatureNotImplemented.
 	Read(mask GPIOValue) (GPIOValue, error)
 	// WaitForEdge blocks for a GPIO line change event to happen. If the does
-	// not implement gpio.PinIn, or doesn't support this capability, 
+	// not implement gpio.PinIn, or doesn't support this capability,
 	// implementations should return gpio.GroupFeatureNotImplemented.
 	//
 	// Number is the GPIO pin number within the group that had an edge change.

--- a/gpio/group.go
+++ b/gpio/group.go
@@ -48,10 +48,10 @@ type Group interface {
 	// If the device doesn't support write operations, implementations should
 	// return gpio.ErrGroupFeatureNotImplemented.
 	Out(value, mask GPIOValue) error
-	// In reads the pins within the group, and returns the  value, ANDed with
+	// Read reads the pins within the group, and returns the  value, ANDed with
 	// mask. If the device doesn't support read operations, implementations
 	// should return gpio.ErrGroupFeatureNotImplemented.
-	In(mask GPIOValue) (GPIOValue, error)
+	Read(mask GPIOValue) (GPIOValue, error)
 	// WaitForEdge blocks for a GPIO line change event to happen. If the does
 	// not implement gpio.PinIn, or doesn't support this capability,
 	// implementations should return gpio.ErrGroupFeatureNotImplemented.

--- a/gpio/group.go
+++ b/gpio/group.go
@@ -33,7 +33,7 @@ type Group interface {
 	// Given a specific pin offset within the group, return that pin.
 	// For example, a pin group may be GPIO pins 3,5,7,9 in that order.
 	// ByOffset(1) returns GPIO pin 5.
-	ByOffset(number int) pin.Pin
+	ByOffset(offset int) pin.Pin
 	// Given the unique name of a GPIO pin, return that pin.
 	ByName(name string) pin.Pin
 	// Given the specific GPIO pin number, return the corresponding

--- a/gpio/group.go
+++ b/gpio/group.go
@@ -48,10 +48,10 @@ type Group interface {
 	// If the device doesn't support write operations, implementations should
 	// return gpio.ErrGroupFeatureNotImplemented.
 	Out(value, mask GPIOValue) error
-	// Read reads the pins within the group, and returns the  value, ANDed with
+	// In reads the pins within the group, and returns the  value, ANDed with
 	// mask. If the device doesn't support read operations, implementations
 	// should return gpio.ErrGroupFeatureNotImplemented.
-	Read(mask GPIOValue) (GPIOValue, error)
+	In(mask GPIOValue) (GPIOValue, error)
 	// WaitForEdge blocks for a GPIO line change event to happen. If the does
 	// not implement gpio.PinIn, or doesn't support this capability,
 	// implementations should return gpio.ErrGroupFeatureNotImplemented.

--- a/gpio/group.go
+++ b/gpio/group.go
@@ -17,7 +17,7 @@ type GPIOValue uint64
 // Implementations that don't implement specific interface methods should
 // return GroupFeatureNotImplemented as the error to allow clients to
 // generically check for the condition.
-var GroupFeatureNotImplemented = errors.New("gpio group feature not implemented")
+var ErrGroupFeatureNotImplemented = errors.New("gpio group feature not implemented")
 
 // Group is an interface that an IO device can implement to manipulate multiple
 // IO Pins at one time. Performing GPIO Operations in this manner can dramatically


### PR DESCRIPTION
Fixes #30 

The idea behind this interface is to give users a way to atomically modify multiple GPIO pins in one transaction. 

This is essentially the interface for the LineSet I created for the IOCTL based GPIO. I'll have another PR coming to make the gpioioctl LineSet implement this interface.

I'll be adding this interface to the MCP23008, and implementing it in a future driver for a CP-2112, and MCP2201, etc. Using this Group() will make writing GPIO Backpacks for things like LCDs trivial. We can have one HD44780 GPIOBackpack that takes a Group, along with a reset and Enable pin.